### PR TITLE
ci: build main + fix README status badge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches-ignore: [main]   # main = release branch → release.yml; PRs inherit via head SHA
+    branches: ['**']   # all branches incl. main, NOT tags (tags → release flow)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![License](https://img.shields.io/github/license/mashape/apistatus.svg?maxAge=2592000)]()
 [![](https://jitpack.io/v/ZrdJ/java-primitives.svg)](https://jitpack.io/#ZrdJ/java-primitives)
-![GitHub Workflow Status (branch)](https://github.com/zrdj/java-primitives/actions/workflows/maven.yml/badge.svg)
+![GitHub Workflow Status (branch)](https://github.com/ZrdJ/java-primitives/actions/workflows/build.yml/badge.svg)
 
 # java-primitives
 


### PR DESCRIPTION
Follow-up: die CI-Standard-PR wurde gemergt, **bevor** zwei Korrekturen drauf waren (Timing). Diese PR zieht sie nach:

- **build.yml**: `push: branches: ['**']` (inkl. `main`) statt `branches-ignore: [main]`. `release.yml` (JitPack) feuert release-getriggert und baut `main` **nicht** → sonst durchläuft ein `main`-Merge gar keine CI.
- **README-Badge**: `actions/workflows/maven.yml` → `build.yml` + Org-Casing `zrdj` → `ZrdJ` (war broken nach dem Rename).

Reviewer + Assignee (codejanovic) werden automatisch via CODEOWNERS + auto-assign gesetzt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)