### PR TITLE
chore: fix trivial SonarQube code smells (S1124, S2293, S1170)

### DIFF
--- a/src/main/java/com/github/zrdj/java/primitives/codec/hex/HexCodec.java
+++ b/src/main/java/com/github/zrdj/java/primitives/codec/hex/HexCodec.java
@@ -3,7 +3,7 @@ package com.github.zrdj.java.primitives.codec.hex;
 import com.github.zrdj.java.primitives.codec.Codec;
 
 public final class HexCodec implements Codec {
-    private final String _hexCharacters = "0123456789abcdef";
+    private static final String _hexCharacters = "0123456789abcdef";
 
     private StringBuilder internalEncode(final byte[] bytes) {
         StringBuilder result = new StringBuilder(2 * bytes.length);

--- a/src/main/java/com/github/zrdj/java/primitives/exception/Exceptions.java
+++ b/src/main/java/com/github/zrdj/java/primitives/exception/Exceptions.java
@@ -16,14 +16,14 @@ public interface Exceptions {
     }
 
     static <T> FunctionExceptionHandler<T> rethrowingFunction(final Function<Exception, RuntimeException> mapper) {
-        return new RethrowingExceptionHandler<T>(mapper);
+        return new RethrowingExceptionHandler<>(mapper);
     }
 
     static <T> T fallbackFunction(final ExceptionFunction<T> function, final Function<Exception, T> mapper) {
-        return new SwallowingFunctionExceptionHandler<T>(mapper).execute(function);
+        return new SwallowingFunctionExceptionHandler<>(mapper).execute(function);
     }
 
     static <T> FunctionExceptionHandler<T> fallbackingFunction(final Function<Exception, T> mapper) {
-        return new SwallowingFunctionExceptionHandler<T>(mapper);
+        return new SwallowingFunctionExceptionHandler<>(mapper);
     }
 }

--- a/src/main/java/com/github/zrdj/java/primitives/text/AbstractText.java
+++ b/src/main/java/com/github/zrdj/java/primitives/text/AbstractText.java
@@ -38,7 +38,7 @@ public abstract class AbstractText implements Text {
     }
 
     @Override
-    abstract public int hashCode();
+    public abstract int hashCode();
 
-    abstract protected boolean isEqualTo(final String other);
+    protected abstract boolean isEqualTo(final String other);
 }


### PR DESCRIPTION
## Summary

Fixes 5 issues across 3 whitelisted SonarQube rules. No public API changes.

- **S1124 — modifier order** (2 issues): `AbstractText.java` lines 41+43 — reordered `abstract public` → `public abstract` and `abstract protected` → `protected abstract` to comply with JLS
- **S2293 — diamond operator** (2 issues): `Exceptions.java` lines 19+27 — replaced explicit type arguments `<T>` with `<>` in constructor calls to `RethrowingExceptionHandler` and `SwallowingFunctionExceptionHandler`
- **S1170 — make final field static** (1 issue): `HexCodec.java` line 6 — added `static` to `private final String _hexCharacters` (field is `private`, no API impact)

No S1170 issues were skipped for visibility — the only S1170 issue was on a `private` field.

## Out of scope (not touched)
All other open issues (S116 field naming, S115 constant naming, S2160 equals, S112 exceptions, bugs, vulnerabilities) are left untouched per scope constraints.

## Test plan
- [x] `mvn -q -DskipTests compile` passes inside devcontainer (verified before push)
- [ ] Full test run (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)